### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Requirements:
 
  * pytz (to localize timezones)
 
+ * numpy (to calculate workout variables)
+
  * FIT files to convert (if using that feature)
 
  * GPX files to convert (if using that feature)


### PR DESCRIPTION
This PR adds `numpy` to the list of required pip modules for this repository.

Running process_all.py crashes with the following error:
```
Traceback (most recent call last):
  File "fit-processing/process_all.py", line 7, in <module>
    import calculate_workout_variables
  File "fit-processing/calculate_workout_variables.py", line 2, in <module>
    import numpy as np 
ModuleNotFoundError: No module named 'numpy'
```

`numpy` therefore needs to be installed (pip install numpy) and has been added to the README.