### PR TITLE
Fix install instructions in README because of package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Requirements:
 
 First, install `fitparse`
 
-    sudo pip3 install -e git+https://github.com/dtcooper/python-fitparse#egg=python-fitparse
+    sudo pip3 install -e git+https://github.com/dtcooper/python-fitparse#egg=fitparse
 
 OR
 


### PR DESCRIPTION
Copying and pasting the pip3 install line, I got the following error:

```
Discarding git+https://github.com/dtcooper/python-fitparse#egg=python-fitparse: Requested fitparse from git+https://github.com/dtcooper/python-fitparse#egg=python-fitparse has inconsistent name: filename has 'python-fitparse', but metadata has 'fitparse'
ERROR: Could not find a version that satisfies the requirement python-fitparse (unavailable) (from versions: none)
ERROR: No matching distribution found for python-fitparse (unavailable)
```

Switching the egg name fixed it.